### PR TITLE
Add Swagger support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Java-SpringBoot
 Java 언어와 SpringBoot 프레임워크 Check!
+
+## Swagger UI
+
+`springdoc-openapi-starter-webmvc-ui` 의존성을 추가하여 Swagger UI를 사용할 수 있습니다.
+애플리케이션을 실행 후 `/swagger-ui.html` 경로에서 확인할 수 있습니다.

--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,11 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-web-services'
-	compileOnly 'org.projectlombok:lombok'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-web-services'
+        // Swagger/OpenAPI support
+        implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+        compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.microsoft.sqlserver:mssql-jdbc'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/nwjs/nwnt/HelloController.java
+++ b/src/main/java/com/nwjs/nwnt/HelloController.java
@@ -1,0 +1,12 @@
+package com.nwjs.nwnt;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+    @GetMapping("/hello")
+    public String hello() {
+        return "Hello, World!";
+    }
+}


### PR DESCRIPTION
## Summary
- add `springdoc-openapi-starter-webmvc-ui` for Swagger UI
- create a simple `HelloController`
- document how to open Swagger UI in README

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6862c573444883268e7e14f891c8ef6a